### PR TITLE
Override theme card width

### DIFF
--- a/lib/web/Person.module.scss
+++ b/lib/web/Person.module.scss
@@ -1,5 +1,8 @@
 .container {
-  max-width: 100%;
+  /* Override the theme configuration for this container. The theme
+   * defines the property inline, so we must use !important to override
+   * the property when this value is pulled from a CSS file. */
+  max-width: 100% !important;
 }
 
 .cardBody {


### PR DESCRIPTION
Override the card width to make it take up the full available space. By default, the theme bases the card width on the size of the content, but I need it to expand to its container.

This is kind of awkward because the theme has a higher priority than any styles I define in this file. For now, I've used `!important` but the better solution is likely to define my own theme or otherwise customize the theme in use at a higher level.