### PR TITLE
Simplify media queries for responsive layout

### DIFF
--- a/lib/web/Landing.module.scss
+++ b/lib/web/Landing.module.scss
@@ -1,10 +1,11 @@
 .landing {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-}
 
-@media screen and (max-width: $breakpoint-xs) {
-  .landing {
+  // On large screens, the layout will be horizontal side-by-side cards.
+  grid-template-columns: repeat(2, 1fr);
+
+  @include smaller-than(small) {
+    // On small screens, the layout will be vertical stacked cards.
     grid-template-columns: 1fr;
   }
 }
@@ -13,28 +14,32 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
+  // Horizontal view should show the question on the left, taking up all vertical space.
+  height: 100vh;
+
+  @include smaller-than(small) {
+    // Vertical view should show question at the top without unnecessary padding.
+    height: auto;
+  }
 }
 
 .questionText {
-  @include large-font();
   font-weight: 600;
   text-align: center;
-}
 
-@media screen and (min-width: $breakpoint-xs) {
-  .questionContainer {
-    height: 100vh;
-    width: 50vw;
-  }
-  .questionText {
-    position: fixed;
-    width: 40vw;
-  }
-}
+  // Horizontal view fixes the question in place so the cards can be scrolled.
+  position: fixed;
 
-@media screen and (max-width: $breakpoint-xs) {
-  .questionText {
+  width: 30vw;
+  font-size: min(6vw, 110px);
+
+  @include smaller-than(small) {
+    // Vertical view allows the question to disappear as the user scrolls.
+    position: unset;
+
     width: 80vw;
+    font-size: 10vw;
   }
 }
 
@@ -45,12 +50,10 @@
 }
 
 .person {
-  margin: 10px 10px 10px 10px;
-}
+  margin: 20px 40px 20px 10px;
+  max-width: 800px;
 
-@media screen and (min-width: $breakpoint-xs) {
-  .person {
-    margin: 20px 40px 20px 10px;
-    max-width: 800px;
+  @include smaller-than(small) {
+    margin: 10px 10px 10px 10px;
   }
 }

--- a/lib/web/Person.module.scss
+++ b/lib/web/Person.module.scss
@@ -23,7 +23,11 @@
 }
 
 .nameText {
-  @include medium-font();
   text-align: center;
   font-weight: 500;
+  font-size: min(3.5vw, 60px);
+
+  @include smaller-than(small) {
+    font-size: 7vw;
+  }
 }

--- a/lib/web/base.scss
+++ b/lib/web/base.scss
@@ -1,48 +1,17 @@
+@use "sass:map";
 @use "sass:math";
 
-$breakpoint-xs: 650px;
-$breakpoint-xl: 1920px;
+$breakpoints: (
+  small: 650px,
+  large: 1920px,
+);
 
-@function strip-unit($value) {
-  @return math.div($value, ($value * 0 + 1));
-}
-
-// Based on https://css-tricks.com/snippets/css/fluid-typography/
-@mixin fluid-type($min-font-size, $max-font-size) {
-  $min-vw: $breakpoint-xs;
-  $max-vw: $breakpoint-xl;
-
-  $u1: unit($min-vw);
-  $u2: unit($max-vw);
-  $u3: unit($min-font-size);
-  $u4: unit($max-font-size);
-
-  @if $u1 == $u2 and $u1 == $u3 and $u1 == $u4 {
-    & {
-      font-size: $min-font-size;
-      @media screen and (min-width: $min-vw) {
-        font-size: calc(
-          #{$min-font-size} + #{strip-unit($max-font-size - $min-font-size)} *
-            ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)})
-        );
-      }
-      @media screen and (min-width: $max-vw) {
-        font-size: $max-font-size;
-      }
-    }
+// Defines a media query based on "max-width" for the provided breakpoint.
+@mixin smaller-than($display) {
+  @if (not map.has-key($breakpoints, $display)) {
+    @error ("Breakpoint '#{$display}' does not exist.");
   }
-}
-
-@mixin medium-font() {
-  $min_font: 30px;
-  $max_font: 60px;
-
-  @include fluid-type($min_font, $max_font);
-}
-
-@mixin large-font() {
-  $min_font: 45px;
-  $max_font: 80px;
-
-  @include fluid-type($min_font, $max_font);
+  @media (max-width: map.get($breakpoints, $display)) {
+    @content;
+  }
 }


### PR DESCRIPTION
Fixes #4 

This PR simplifies the existing media queries to clear up the layout. The font size adjustment was very complex previously, and it was possible to simplify using `min` and some of the relative units. 

I have also added a new function in `base.scss` which makes the media queries more terse, and allows them to be placed within the other styling blocks that they apply to.